### PR TITLE
[WB-1992] i18next

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,66 @@
-# i18next-endings-postprocessor
+# `i18next-endings-postprocessor`
 
 ### Introduction
-In russian, for example, words endings depend not only on plural or singular, as it is in English.
+
+In many languages, words endings depend not only on plural or singular form, but also on the number itself. For example, in Russian, the word "day" has three forms: "день", "дня" and "дней". This postprocessor allows you to use such forms in your translations.
+
+It built on top of native [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules).
+
+> Warning! `i18next` has [built-in pluralization support](https://www.i18next.com/translation-function/plurals). The only difference is that this postprocessor allows you to use many counters in the one string.
 
 ### Getting started
 
 ```bash
 npm i --save i18next-endings-postprocessor
 ```
+
 ```javascript
-import i18next      from 'i18next';
-import I18nEndings  from 'i18next-endings-postprocessor';
+import i18next from "i18next";
+import I18nEndings from "i18next-endings-postprocessor";
 
 const config = {
-	postProcess: ['endings']
-}
+  postProcess: ["endings"],
+};
 
 i18next.use(new I18nEndings()).init(config);
-
 ```
 
 ### Usage
+
 ```
-  n   1    2-4    5-20 
-[[1|first|second|third]]
+[[n|zero|one|two|few|many|other]]
 ```
 
+> If your language does not have particular plural case (e.g. 'zero'), you can skip it.
+
 ##### JSON
+
 ```
 {
-	"key": "some string {{count}} [[{{count}}|first|second|third]] variant"
+	"key": "some string {{count}} [[{{count}}|first|second]] variant"
 }
 ```
 
 ##### JS
-```javascript
-i18next.t('key', { count: 1}); // -> some string 1 first variant
-i18next.t('key', { count: 2}); // -> some string 2 second variant
-i18next.t('key', { count: 5}); // -> some string 5 third variant
-i18next.t('key', { count: 20}); // -> some string 20 third variant
-i18next.t('key', { count: 21}); // -> some string 21 first variant
-i18next.t('key', { count: 22}); // -> some string 22 second variant
 
-//float value always returns second variant
-i18next.t('key', { count: 1.1}); // -> some string 1.1 second variant
+```javascript
+i18next.t("key", { count: 1 }); // -> some string 1 first variant
+i18next.t("key", { count: 2 }); // -> some string 2 second variant
+i18next.t("key", { count: 5 }); // -> some string 5 second variant
+i18next.t("key", { count: 20 }); // -> some string 20 second variant
+i18next.t("key", { count: 21 }); // -> some string 21 second variant
+i18next.t("key", { count: 22 }); // -> some string 22 second variant
+
+// float value always returns last variant
+i18next.t("key", { count: 1.1 }); // -> some string 1.1 second variant
 ```
 
-
 ### Customize
-You can set formatting function for each language. If function for lang not set, will used default.
+
+> Warning! We do not have any tests for this feature. Use it at your own risk.
+
+You can set formatting function for each language. If function for language not set, will use default.
+
 ```javascript
 i18next.use(new I18nEndings({
 	pt_BR: (num : Number, arrOfVariants: Array<String>) : String

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 In many languages, words endings depend not only on plural or singular form, but also on the number itself. For example, in Russian, the word "day" has three forms: "день", "дня" and "дней". This postprocessor allows you to use such forms in your translations.
 
-It built on top of native [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules).
-
-> Warning! `i18next` has [built-in pluralization support](https://www.i18next.com/translation-function/plurals). The only difference is that this postprocessor allows you to use many counters in the one string. It helps to safe full sentence meaning in one key.
+It built on top of native [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules). This postprocessor allows you to use many counters in the one string. It helps to safe full sentence meaning in one key.
 
 ### Getting started
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ In many languages, words endings depend not only on plural or singular form, but
 
 It built on top of native [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules).
 
-> Warning! `i18next` has [built-in pluralization support](https://www.i18next.com/translation-function/plurals). The only difference is that this postprocessor allows you to use many counters in the one string.
+> Warning! `i18next` has [built-in pluralization support](https://www.i18next.com/translation-function/plurals). The only difference is that this postprocessor allows you to use many counters in the one string. It helps to safe full sentence meaning in one key.
 
 ### Getting started
 
@@ -56,8 +56,6 @@ i18next.t("key", { count: 1.1 }); // -> some string 1.1 second variant
 ```
 
 ### Customize
-
-> Warning! We do not have any tests for this feature. Use it at your own risk.
 
 You can set formatting function for each language. If function for language not set, will use default.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "i18next-endings-postprocessor",
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "i18next-endings-postprocessor",
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"license": "MIT",
 			"devDependencies": {
 				"i18next": "^23.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "i18next-endings-postprocessor",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "i18next-endings-postprocessor",
-			"version": "3.0.0",
+			"version": "3.1.0",
 			"license": "MIT",
 			"devDependencies": {
 				"i18next": "^23.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "i18next-endings-postprocessor",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"description": "i18next endings postprocessor",
 	"type": "module",
 	"main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "i18next-endings-postprocessor",
-	"version": "3.0.1",
+	"version": "3.1.0",
 	"description": "i18next endings postprocessor",
 	"type": "module",
 	"main": "src/index.js",

--- a/src/i18n_endings.en.test.js
+++ b/src/i18n_endings.en.test.js
@@ -1,0 +1,38 @@
+import { describe, test, expect } from "vitest";
+import i18next from "i18next";
+
+import I18nEndings from "./index";
+
+const t = await i18next.use(new I18nEndings()).init({
+  postProcess: ["endings"],
+  lng: "en",
+  resources: {
+    en: {
+      translation: {
+        /**
+         * It's invalid format for English, because it has to have only 2 cases
+         * but in source code of Aviasales there are a lot of strings with 3 cases
+         */
+        key: "some string {{count}} [[{{count}}|first|second|third]] variant",
+      },
+    },
+  },
+});
+
+describe("I18nEndings (en)", () => {
+  test.each([
+    // simple cases
+    { count: 1, expected: "some string 1 first variant" },
+    { count: 2, expected: "some string 2 second variant" },
+    { count: 5, expected: "some string 5 third variant" },
+    { count: 20, expected: "some string 20 third variant" },
+    { count: 21, expected: "some string 21 second variant" },
+    { count: 22, expected: "some string 22 second variant" },
+    // special cases
+    { count: 1.1, expected: "some string 1.1 second variant" },
+  ])("count $count", ({ count, expected }) => {
+    const result = t("key", { count });
+
+    expect(result).toBe(expected);
+  });
+});

--- a/src/i18n_endings.ru.test.js
+++ b/src/i18n_endings.ru.test.js
@@ -17,7 +17,7 @@ const t = await i18next.use(new I18nEndings()).init({
   },
 });
 
-describe("I18nEndings", () => {
+describe("I18nEndings (ru)", () => {
   test.each([
     // simple cases
     { count: 1, expected: "Пора покупать 1 билет!" },
@@ -31,7 +31,7 @@ describe("I18nEndings", () => {
     { count: 9, expected: "Пора покупать 9 билетов!" },
     { count: 10, expected: "Пора покупать 10 билетов!" },
     { count: 11, expected: "Пора покупать 11 билетов!" },
-    // // special cases
+    // special cases
     { count: 0, expected: "Пора покупать 0 билетов!" },
     { count: 21, expected: "Пора покупать 21 билет!" },
     { count: 25, expected: "Пора покупать 25 билетов!" },

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ export default class I18nEndings {
 			return this.options[translator.language](number, values);
 		}
 		
+		let numericCase = 0
 		try {
 			/**
 			 * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/resolvedOptions}
@@ -35,7 +36,7 @@ export default class I18nEndings {
 			  availableCases.includes(item)
 			);
 	  
-			numbericCase = order.indexOf(textCase);
+			numericCase = order.indexOf(textCase);
 		  } catch (e) {}
 		
 		return values[numericCase];

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+const REFERENCE_ORDER = ["zero", "one", "two", "few", "many", "other"];
+
 export default class I18nEndings {
 	type = 'postProcessor';
 	name = 'endings';
@@ -12,24 +14,31 @@ export default class I18nEndings {
 			return this.options[translator.language](number, values);
 		}
 		
-		/**
-		 * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/select}
-		 * @type {'zero' | 'one' | 'two' | 'few' | 'many' | 'other'}
-		 */
-		let textCase = 'few';
 		try {
-			textCase = translator.pluralResolver.getRule(translator.language).select(number);
-		} catch (e) {
-		}
-
-		const numericCase = {
-			'one': 0,
-			'few': 1,
-			'many': 2,
-			'other': 1,
-		}
+			/**
+			 * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/resolvedOptions}
+			 * @type {Array<'zero' | 'one' | 'two' | 'few' | 'many' | 'other'>}
+			 */
+			const availableCases = translator.pluralResolver
+			  .getRule(translator.language)
+			  .resolvedOptions().pluralCategories;
+	  
+			/**
+			 * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/select}
+			 * @type {'zero' | 'one' | 'two' | 'few' | 'many' | 'other'}
+			 */
+			let textCase = translator.pluralResolver
+			  .getRule(translator.language)
+			  .select(number);
+	  
+			const order = REFERENCE_ORDER.filter((item) =>
+			  availableCases.includes(item)
+			);
+	  
+			numbericCase = order.indexOf(textCase);
+		  } catch (e) {}
 		
-		return values[numericCase[textCase] || 0];
+		return values[numericCase];
 	}
 	
 	process(value, key, options, translator) {


### PR DESCRIPTION
Раньше плагин неявно позволял определять кейсы в массиве, после релиза 3 стал требовать явных трех элементов. Теперь работает как раньше, а эта особенность описана в документации.

Так как в Авиасейлс многие английские строки завязаны на кривые массивы (3 элемента вместо 2), в тестах оставил тоже три элемента (как и было в доке). В доке исправил, чтобы никто не завязывался на это.

Бонусом, добавил в документацию ворнинги — про то, что в i18next есть нативный механизм и про то, что часть фич не покрыта тестами и гарантировать их работоспособность невозможно.